### PR TITLE
Add fallback to search for html element by name

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 screenshot.png
+.venv

--- a/config.yaml
+++ b/config.yaml
@@ -1,32 +1,32 @@
 elements:
   storage_price:
-    label: 'Storage Price'
+    label: 'Storage Price (SCP/TB/month)'
     xpath: '/html/body/div/div/div[2]/div[3]/div[2]/div/div[1]/div/div[2]/div[10]/div/div[1]/div/div[2]/div/div[1]/div/div/div[2]/div/span[1]'
     command: minstorageprice
     unit: SCP
   collateral_price:
-    label: 'Collateral Price'
+    label: 'Collateral (SCP/TB/month)'
     xpath: '/html/body/div/div/div[2]/div[3]/div[2]/div/div[1]/div/div[2]/div[10]/div/div[1]/div/div[2]/div/div[2]/div/div/div[2]/div/span[1]'
     command: collateral
     unit: SCP
   max_collateral:
-    label: 'Max Collateral'
+    label: 'Max Collateral (SCP/contract)'
     xpath: '/html/body/div/div/div[2]/div[3]/div[2]/div/div[1]/div/div[2]/div[10]/div/div[1]/div/div[2]/div/div[3]/div/div/div[2]/div/span[1]'
     command: maxcollateral
     unit: SCP
   download_bandwith_price:
-    label: 'Download Bandwith Price'
+    label: 'Download Bandwith Price (SCP/TB)'
     xpath: '/html/body/div/div/div[2]/div[3]/div[2]/div/div[1]/div/div[2]/div[10]/div/div[1]/div/div[2]/div/div[4]/div/div/div[2]/div/span[1]'
     command: mindownloadbandwidthprice
     unit: SCP
   upload_bandwith_price:
-    label: 'Upload Bandwith Price'
+    label: 'Upload Bandwith Price (SCP/TB)'
     xpath: '/html/body/div/div/div[2]/div[3]/div[2]/div/div[1]/div/div[2]/div[10]/div/div[1]/div/div[2]/div/div[5]/div/div/div[2]/div/span[1]'
     command: minuploadbandwidthprice
     unit: SCP
   contract_duration:
-    label: 'Contract Duration'
+    label: 'Max Duration'
     xpath: '/html/body/div/div/div[2]/div[3]/div[2]/div/div[1]/div/div[2]/div[10]/div/div[1]/div/div[2]/div/div[6]/div/div/div[2]/div/span[1]'
   contract_creation_fee:
-    label: 'Contract Creation Fee'
+    label: 'Contract Creation Fee (SCP)'
     xpath: '/html/body/div/div/div[2]/div[3]/div[2]/div/div[1]/div/div[2]/div[10]/div/div[1]/div/div[2]/div/div[7]/div/div/div[2]/div/span[1]'

--- a/config.yaml
+++ b/config.yaml
@@ -1,26 +1,26 @@
 elements:
   storage_price:
-    label: 'Storage Price (SCP/TB/month)'
+    label: 'Storage Price'
     xpath: '/html/body/div/div/div[2]/div[3]/div[2]/div/div[1]/div/div[2]/div[10]/div/div[1]/div/div[2]/div/div[1]/div/div/div[2]/div/span[1]'
     command: minstorageprice
     unit: SCP
   collateral_price:
-    label: 'Collateral (SCP/TB/month)'
+    label: 'Collateral Price'
     xpath: '/html/body/div/div/div[2]/div[3]/div[2]/div/div[1]/div/div[2]/div[10]/div/div[1]/div/div[2]/div/div[2]/div/div/div[2]/div/span[1]'
     command: collateral
     unit: SCP
   max_collateral:
-    label: 'Max Collateral (SCP/contract)'
+    label: 'Max Collateral'
     xpath: '/html/body/div/div/div[2]/div[3]/div[2]/div/div[1]/div/div[2]/div[10]/div/div[1]/div/div[2]/div/div[3]/div/div/div[2]/div/span[1]'
     command: maxcollateral
     unit: SCP
   download_bandwith_price:
-    label: 'Download Bandwith Price (SCP/TB)'
+    label: 'Download Bandwith'
     xpath: '/html/body/div/div/div[2]/div[3]/div[2]/div/div[1]/div/div[2]/div[10]/div/div[1]/div/div[2]/div/div[4]/div/div/div[2]/div/span[1]'
     command: mindownloadbandwidthprice
     unit: SCP
   upload_bandwith_price:
-    label: 'Upload Bandwith Price (SCP/TB)'
+    label: 'Upload Bandwith'
     xpath: '/html/body/div/div/div[2]/div[3]/div[2]/div/div[1]/div/div[2]/div[10]/div/div[1]/div/div[2]/div/div[5]/div/div/div[2]/div/span[1]'
     command: minuploadbandwidthprice
     unit: SCP

--- a/main.py
+++ b/main.py
@@ -1,37 +1,11 @@
 import argparse
 import yaml
 import asyncio
+import re
 
 from bs4 import BeautifulSoup
 from lxml import etree
 from pyppeteer import launch
-
-parser = argparse.ArgumentParser(description='Process grafana settings')
-parser.add_argument('--config', '-c', help='Path to config file', required=False, default='config.yaml')
-parser.add_argument('--url', '-u', help='Grafana provider url', required=False)
-parser.add_argument('--provider-id', '-p', help='Grafana provider id', required=False)
-parser.add_argument('--commands', help='Prints commands that need to be run', required=False, default=False, action='store_true')
-parser.add_argument('--screenshot', help='Saves a screenshot of grafane for debug purposes', required=False, default=False, action='store_true')
-parser.add_argument(
-    '--update_settings',
-    help='Which settings should be automatically updated', required=False, default=[])
-
-args = parser.parse_args()
-if args.update_settings:
-    args.update_settings = args.update_settings.split(',')
-
-if not args.url and not args.provider_id:
-    print("Please provide a grafana url or a provider id")
-    exit(1)
-
-if not args.url:
-    args.url = 'https://grafana.scpri.me/d/Cg7V28sMk/provider-detail?var-provider=' + args.provider_id
-
-with open(args.config, "r") as stream:
-    try:
-        configs = yaml.safe_load(stream)
-    except yaml.YAMLError as exc:
-        print(exc)
 
 
 async def main():
@@ -73,10 +47,16 @@ async def main():
         dom_element = dom.xpath(element['xpath'])
 
         if not dom_element:
-            print('Element %s not found. Debug with --screenshot or check your configuration file!' % element_name)
-            continue
+            # fallback to search by name for the element
+            dom_element = soup.find(text=re.compile(re.escape(element['label']))).parent.next_sibling.div
+            if not dom_element:
+                print('Element %s not found. Debug with --screenshot or check your configuration file!' % element_name)
+                continue
+            else:
+                element_value = dom_element.contents[0].text
+        else:
+            element_value = dom_element[0].text
 
-        element_value = dom.xpath(element['xpath'])[0].text
         if args.commands and 'command' in element:
             print('spc host config %s %s%s' % (element['command'], element_value, element['unit']))
         elif not args.commands:
@@ -84,4 +64,32 @@ async def main():
 
     await browser.close()
 
-asyncio.get_event_loop().run_until_complete(main())
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description='Process grafana settings')
+    parser.add_argument('--config', '-c', help='Path to config file', required=False, default='config.yaml')
+    parser.add_argument('--url', '-u', help='Grafana provider url', required=False)
+    parser.add_argument('--provider-id', '-p', help='Grafana provider id', required=False)
+    parser.add_argument('--commands', help='Prints commands that need to be run', required=False, default=False, action='store_true')
+    parser.add_argument('--screenshot', help='Saves a screenshot of grafane for debug purposes', required=False, default=False, action='store_true')
+    parser.add_argument(
+        '--update_settings',
+        help='Which settings should be automatically updated', required=False, default=[])
+
+    args = parser.parse_args()
+    if args.update_settings:
+        args.update_settings = args.update_settings.split(',')
+
+    if not args.url and not args.provider_id:
+        print("Please provide a grafana url or a provider id")
+        exit(1)
+
+    if not args.url:
+        args.url = 'https://grafana.scpri.me/d/Cg7V28sMk/provider-detail?var-provider=' + args.provider_id
+
+    with open(args.config, "r") as stream:
+        try:
+            configs = yaml.safe_load(stream)
+        except yaml.YAMLError as exc:
+            print(exc)
+
+    asyncio.get_event_loop().run_until_complete(main())


### PR DESCRIPTION
- Fallback to search for html element by name as specified in config.yaml
- Update config.yaml labels to match current Grafana strings for each setting
- Add __name__ == 'main' in case we want to import

Searching by name may give the script more resiliency as the Grafana HTML changes from time to time